### PR TITLE
Fix: Correct timer audio and finalize settings relocation

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -120,6 +120,7 @@ const Settings = (function() {
             showSeparators: true,
             separatorMode: 'standard',
             alarmSound: 'bell01.mp3',
+            timerSound: 'nice_digital_watch.mp3',
             stopwatchSound: 'Tick_Tock.wav',
             arcVisibility: {
                 dayOfWeek: false,

--- a/js/tools.js
+++ b/js/tools.js
@@ -177,7 +177,7 @@ const Tools = (function() {
 
     function timerFinished() {
         if (state.timer.isInterval) {
-            const audio = playSound(settings.alarmSound);
+            const audio = playSound(settings.timerSound);
             if (audio && state.timer.isMuted) {
                 audio.muted = true;
             }
@@ -197,7 +197,7 @@ const Tools = (function() {
             state.timer.isRunning = false;
             state.timer.alarmPlaying = true;
             state.timer.remainingSeconds = 0;
-            const audio = playSound(settings.alarmSound);
+            const audio = playSound(settings.timerSound);
             if (audio) {
                 state.timer.currentAudio = audio;
                 if (state.timer.isMuted) {
@@ -464,7 +464,7 @@ const Tools = (function() {
         }
 
         if (playSoundOnStart && !state.pomodoro.isMuted) {
-            playSound(settings.alarmSound);
+            playSound(settings.timerSound);
         }
         updatePomodoroDashboard();
         state.pomodoro.isRunning = true; // Auto-start the next cycle
@@ -795,7 +795,7 @@ const Tools = (function() {
                         pomodoroActions.style.display = 'flex';
                     }
                     if (!state.pomodoro.lastMinuteSoundPlayed && !state.pomodoro.endOfCycleSoundPlayed) {
-                        const audio = playSound(settings.alarmSound);
+                        const audio = playSound(settings.timerSound);
                         if (audio) {
                             state.pomodoro.currentAudio = audio;
                             if (state.pomodoro.isMuted) {
@@ -818,7 +818,7 @@ const Tools = (function() {
                         state.pomodoro.remainingSeconds = 0;
                         state.pomodoro.alarmPlaying = true;
                         if (!state.pomodoro.isMuted) {
-                            playSound(settings.alarmSound || 'bell01.mp3');
+                            playSound(settings.timerSound || 'bell01.mp3');
                         }
                         updatePomodoroUI();
                     }


### PR DESCRIPTION
This commit addresses two issues:
1.  It fixes a bug where end-of-cycle audio for timers and Pomodoro cycles would fail to play. This was caused by referencing a non-existent `timerSound` setting. The code has been corrected to use the appropriate `alarmSound` setting for these alerts, which was then changed to a new, less jarring `timerSound` setting per user feedback.
2.  It finalizes the relocation of the Pomodoro settings into the main tool panel, ensuring the UI is clean and the new live-updating inputs are fully functional.

Changes include:
- Adding a new `timerSound` setting in `js/settings.js` with a more subtle default.
- Updating `js/tools.js` to use `settings.timerSound` for all timer and Pomodoro alerts, decoupling it from the main alarm sound.
- Verifying the relocation of Pomodoro settings UI into the `pomodoroPanel` in `index.html`.
- Verifying the cleanup of old UI logic in `js/ui.js`.