### PR TITLE
Fix: Reset Pomodoro mute state at the start of each new cycle

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -365,12 +365,18 @@ const Tools = (function() {
         state.pomodoro.remainingSeconds = state.pomodoro.workDuration * 60;
         state.pomodoro.alarmPlaying = false;
         state.pomodoro.isMuted = false;
+        mutePomodoroBtn.classList.remove('active');
         state.pomodoro.hasStarted = false;
         state.pomodoro.isOneMinuteWarningPlayed = false;
         state.pomodoro.lastMinuteSoundPlayed = false;
         state.pomodoro.isSnoozing = false;
         state.pomodoro.actionButtonsVisible = false;
         state.pomodoro.endOfCycleSoundPlayed = false;
+
+        // Reset mute state for the new cycle
+        state.pomodoro.isMuted = false;
+        mutePomodoroBtn.classList.remove('active');
+
         if (state.pomodoro.currentAudio) {
             state.pomodoro.currentAudio.pause();
             state.pomodoro.currentAudio = null;


### PR DESCRIPTION
This commit ensures that the Pomodoro timer's mute state is reset at the beginning of each new cycle. If a user mutes the audio during one cycle, the mute will be automatically disabled for the next cycle, allowing the end-of-cycle alert to play.

This is achieved by updating the `startNextPomodoroPhase` and `resetPomodoro` functions in `js/tools.js` to set `state.pomodoro.isMuted` to `false` and to remove the 'active' class from the mute button's UI.