### PR TITLE
fix: Adjust alarm arc to be the outermost ring

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -873,7 +873,7 @@ const Clock = (function() {
             const thinnerLineWidth = renderedLineWidth * 0.5;
             const renderedGap = (1.875 / 57) * baseRadius;
 
-            const arcOrder = ['weekOfYear', 'seconds', 'minutes', 'hours', 'day', 'month', 'dayOfWeek', 'year', 'alarm'];
+            const arcOrder = ['alarm', 'weekOfYear', 'seconds', 'minutes', 'hours', 'day', 'month', 'dayOfWeek', 'year'];
             const arcLineWidths = {
                 day: renderedLineWidth,
                 hours: renderedLineWidth,


### PR DESCRIPTION
This commit adjusts the rendering order of the clock arcs to make the new alarm countdown arc the absolute outermost ring, as requested in follow-up feedback.