### PR TITLE
Refactor: Improve Stopwatch UX and Fix Sound Issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -860,7 +860,6 @@
                     <option value="work_end.mp3">Work End</option>
                 </select>
                 <button id="testStopwatchSoundBtn" class="control-btn">Test</button>
-                <button id="muteStopwatchSoundBtn" class="control-btn">Mute</button>
             </div>
         </div>
         <!-- Time Calculator Panel -->

--- a/js/tools.js
+++ b/js/tools.js
@@ -601,14 +601,8 @@ const Tools = (function() {
 
         document.getElementById('testStopwatchSoundBtn').addEventListener('click', () => {
             if (!state.stopwatch.isMuted) {
-                playSound(settings.stopwatchSound);
+                playSound(settings.stopwatchSound, true);
             }
-        });
-
-        document.getElementById('muteStopwatchSoundBtn').addEventListener('click', () => {
-            state.stopwatch.isMuted = !state.stopwatch.isMuted;
-            document.getElementById('muteStopwatchSoundBtn').classList.toggle('active', state.stopwatch.isMuted);
-            document.dispatchEvent(new CustomEvent('statechange'));
         });
         lapTimesContainer.addEventListener('input', (e) => {
             if (e.target.classList.contains('lap-label-input')) {


### PR DESCRIPTION
This commit applies the same UX improvements to the stopwatch that were previously applied to the timer.

- A bug that allowed the "Test" sound button to be clicked multiple times, causing sounds to stack, has been fixed. Now, only one test sound can play at a time.
- The superfluous "Mute" button in the stopwatch sound settings has been removed.