### PR TITLE
Refactor: Remove Catch Up Time Feature from Stopwatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,14 +835,6 @@
                 <button id="lapStopwatch">Lap</button>
                 <button id="resetStopwatch">Reset</button>
             </div>
-            <div class="settings-section w-full max-w-xs">
-                <h3 class="text-sm uppercase text-gray-400 mt-4">Catch Up Time</h3>
-                <div class="flex items-center justify-center gap-2">
-                    <input type="number" id="catchUpMinutes" class="time-input-small" placeholder="Min" min="0">
-                    <input type="number" id="catchUpSeconds" class="time-input-small" placeholder="Sec" min="0" max="59">
-                    <button id="addCatchUpTimeBtn" class="control-btn">Add Time</button>
-                </div>
-            </div>
             <ul id="lapTimes" class="w-full max-w-xs space-y-2"></ul>
             <div class="setting-item">
                 <label for="stopwatchSoundSelect">Stopwatch Sound</label>

--- a/js/tools.js
+++ b/js/tools.js
@@ -12,9 +12,6 @@ const Tools = (function() {
     const resetStopwatchBtn = document.getElementById('resetStopwatch');
     const lapTimesContainer = document.getElementById('lapTimes');
 
-    const catchUpMinutesInput = document.getElementById('catchUpMinutes');
-    const catchUpSecondsInput = document.getElementById('catchUpSeconds');
-    const addCatchUpTimeBtn = document.getElementById('addCatchUpTimeBtn');
 
     const statusDisplay = document.getElementById('pomodoroStatus');
     const pomodoroWorkDisplay = document.getElementById('pomodoroWorkDisplay');
@@ -243,8 +240,6 @@ const Tools = (function() {
         state.stopwatch.elapsedTime = 0;
         state.stopwatch.laps = [];
         updateLapDisplay();
-        catchUpMinutesInput.value = '';
-        catchUpSecondsInput.value = '';
         if (!state.stopwatch.isMuted) {
             playSound(settings.stopwatchSound);
         }
@@ -279,21 +274,6 @@ const Tools = (function() {
     function formatTime(ms) {
         const d = new Date(ms);
         return `${d.getUTCMinutes().toString().padStart(2, '0')}:${d.getUTCSeconds().toString().padStart(2, '0')}.${d.getUTCMilliseconds().toString().padStart(3, '0')}`;
-    }
-
-    function addManualCatchUpTime() {
-        const minutes = parseInt(catchUpMinutesInput.value) || 0;
-        const seconds = parseInt(catchUpSecondsInput.value) || 0;
-        const timeToAddMs = (minutes * 60 + seconds) * 1000;
-        if (timeToAddMs > 0) {
-            state.stopwatch.elapsedTime += timeToAddMs;
-            if (state.stopwatch.isRunning) {
-                state.stopwatch.startTime -= timeToAddMs;
-            }
-            catchUpMinutesInput.value = '';
-            catchUpSecondsInput.value = '';
-            document.dispatchEvent(new CustomEvent('statechange'));
-        }
     }
 
     // Pomodoro Functions
@@ -593,7 +573,6 @@ const Tools = (function() {
         toggleStopwatchBtn.addEventListener('click', toggleStopwatch);
         resetStopwatchBtn.addEventListener('click', resetStopwatch);
         lapStopwatchBtn.addEventListener('click', lapStopwatch);
-        addCatchUpTimeBtn.addEventListener('click', addManualCatchUpTime);
         document.getElementById('stopwatchSoundSelect').addEventListener('change', (e) => {
             settings.stopwatchSound = e.target.value;
             document.dispatchEvent(new CustomEvent('settings-changed'));


### PR DESCRIPTION
This commit removes the "Catch Up Time" feature from the stopwatch panel, as requested by the user.

The feature was deemed superfluous. The changes include:
- Removal of the "Catch Up Time" section from the stopwatch panel in `index.html`.
- Removal of the associated DOM element selections, the `addManualCatchUpTime` function, and the corresponding event listener from `js/tools.js`.