### PR TITLE
Feat: Add Interval Sound to Stopwatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -836,6 +836,22 @@
                 <button id="resetStopwatch">Reset</button>
             </div>
             <ul id="lapTimes" class="w-full max-w-xs space-y-2"></ul>
+            <div class="settings-section w-full max-w-xs">
+                <div class="setting-toggle">
+                    <span>Interval Sound</span>
+                    <label class="switch">
+                        <input type="checkbox" id="stopwatchIntervalSoundToggle">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div id="stopwatchIntervalInputs" class="flex items-center justify-center gap-2">
+                    <input type="number" id="stopwatchIntervalHours" class="time-input-small" placeholder="HH" min="0" value="0">
+                    <span>:</span>
+                    <input type="number" id="stopwatchIntervalMinutes" class="time-input-small" placeholder="MM" min="0" value="0">
+                    <span>:</span>
+                    <input type="number" id="stopwatchIntervalSeconds" class="time-input-small" placeholder="SS" min="0" value="0">
+                </div>
+            </div>
             <div class="setting-item">
                 <label for="stopwatchSoundSelect">Stopwatch Sound</label>
                 <select id="stopwatchSoundSelect" class="w-full p-2 bg-gray-700 text-white rounded-md" style="max-width: 180px;">


### PR DESCRIPTION
This commit introduces a new feature to the stopwatch that allows users to play a sound at a specified interval.

- A new "Interval Sound" section has been added to the stopwatch panel in `index.html`.
- This section includes a toggle switch to enable or disable the feature and HH:MM:SS inputs to set the interval duration.
- The `js/tools.js` file has been updated to include the necessary state management and logic to track the stopwatch's elapsed time and play the selected sound at the specified intervals.