### PR TITLE
Fix: Move Stopwatch Lap Times to Bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,7 +835,6 @@
                 <button id="lapStopwatch">Lap</button>
                 <button id="resetStopwatch">Reset</button>
             </div>
-            <ul id="lapTimes" class="w-full max-w-xs space-y-2"></ul>
             <div class="settings-section w-full max-w-xs">
                 <div class="setting-toggle">
                     <span>Interval Sound</span>
@@ -869,6 +868,7 @@
                 </select>
                 <button id="testStopwatchSoundBtn" class="control-btn">Test</button>
             </div>
+            <ul id="lapTimes" class="w-full max-w-xs space-y-2"></ul>
         </div>
         <!-- Time Calculator Panel -->
         <div id="timeCalculatorPanel" class="ui-panel panel-hidden">


### PR DESCRIPTION
This commit moves the lap times list to the bottom of the stopwatch panel, as requested by the user. This improves the layout by grouping all the controls and settings together at the top, with the lap times displayed below.