### PR TITLE
feat: Increase tappable area of mobile navigation icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,6 +721,7 @@
             right: auto;
             bottom: auto;
             left: auto;
+            padding: 15px;
         }
 
         /* Adjust the main clock container to prevent overlap */


### PR DESCRIPTION
This commit increases the padding of the navigation icons in the mobile view to make them easier to use on a touchscreen. The padding is increased to 15px for screens with a width of 600px or less.