### PR TITLE
feat: Replace manual resize with clock size slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -987,9 +987,12 @@
                 <!-- Section 1: Clock & Time -->
                 <div class="settings-group">
                     <h3 class="settings-group-title">Clock & Time</h3>
-                    <div class="setting-item">
-                        <label for="manualResizeToggle">Manual Resize</label>
-                        <label class="switch"><input type="checkbox" id="manualResizeToggle"><span class="slider"></span></label>
+                    <div class="setting-item-full">
+                         <div class="flex justify-between w-full mb-1">
+                            <label for="clockSizeSlider">Clock Size</label>
+                            <span id="clockSizeValue" class="text-sm text-gray-400">95%</span>
+                        </div>
+                        <input type="range" id="clockSizeSlider" min="10" max="100" value="95" class="w-full">
                     </div>
                     <div class="setting-item">
                         <label>Time Format</label>

--- a/js/clock.js
+++ b/js/clock.js
@@ -20,10 +20,6 @@ const Clock = (function() {
     let flowTransitionDuration = 1500; // ms
     let previousColors = null;
 
-    // Resizing State
-    let resizeObserver = null;
-    let isResizing = false;
-
     const hasCompletedCycle = (unit, now, lastNow) => {
         switch (unit) {
             case 'seconds':
@@ -828,86 +824,6 @@ const Clock = (function() {
         animationFrameId = requestAnimationFrame(animate);
     };
 
-    const applyResizeMode = () => {
-        const wrapper = document.querySelector('.clock-square-wrapper');
-        if (!wrapper) return;
-
-        if (settings.manualResize) {
-            // Enable CSS resize
-            wrapper.style.resize = 'both';
-            wrapper.style.overflow = 'hidden';
-            wrapper.style.maxWidth = 'none';
-            wrapper.style.maxHeight = 'none';
-            wrapper.style.width = wrapper.style.width || '500px'; // Default start size if none set
-            wrapper.style.height = wrapper.style.width;
-
-            if (!resizeObserver) {
-                resizeObserver = new ResizeObserver(entries => {
-                    for (let entry of entries) {
-                        handleResizeEntry(entry);
-                    }
-                });
-                resizeObserver.observe(wrapper);
-            }
-        } else {
-            // Disable CSS resize
-            wrapper.style.resize = '';
-            wrapper.style.overflow = '';
-            wrapper.style.width = '95vh';
-            wrapper.style.height = '95vh';
-            wrapper.style.maxWidth = '100%';
-            wrapper.style.maxHeight = '100%';
-
-            if (resizeObserver) {
-                resizeObserver.disconnect();
-                resizeObserver = null;
-            }
-            // Trigger a standard resize to reset layout
-            publicInterface.resize();
-        }
-    };
-
-    const handleResizeEntry = (entry) => {
-        if (isResizing) return;
-        isResizing = true;
-
-        requestAnimationFrame(() => {
-            const wrapper = entry.target;
-            const { width, height } = entry.contentRect;
-
-            // 1. Enforce Aspect Ratio (Square)
-            // Use the larger dimension to prevent accidental shrinking when dragging just one edge
-            let size = Math.max(width, height);
-
-            // 2. Enforce Constraints
-            // Min Size: Ensure inner circle is visible
-            const minSize = calculateMinSize();
-            // Max Size: Viewport dimensions
-            const maxSize = Math.min(window.innerWidth, window.innerHeight);
-
-            if (size < minSize) size = minSize;
-            if (size > maxSize) size = maxSize;
-
-            // Apply size
-            wrapper.style.width = `${size}px`;
-            wrapper.style.height = `${size}px`;
-
-            // Trigger internal redraw
-            publicInterface.resize();
-
-            // Save state if needed (handled in persistence step)
-            if (settings.manualResize) {
-                localStorage.setItem('polarClockSize', JSON.stringify({
-                    size: size,
-                    windowWidth: window.innerWidth,
-                    windowHeight: window.innerHeight
-                }));
-            }
-
-            isResizing = false;
-        });
-    };
-
     const calculateMinSize = () => {
         // Calculate minimal size based on visible arcs
         // Base formula: (InnerBuffer + (NumArcs * (LineWidth + Gap))) * 2
@@ -947,14 +863,45 @@ const Clock = (function() {
         return (visibleCount * 50) + 100;
     };
 
+    const applyClockSize = () => {
+        const wrapper = document.querySelector('.clock-square-wrapper');
+        if (!wrapper) return;
+
+        // Base size is relative to the viewport's smallest dimension (to fit in screen)
+        const viewportMin = Math.min(window.innerWidth, window.innerHeight);
+        const scale = (settings.clockScale !== undefined ? settings.clockScale : 95) / 100;
+
+        // Calculate target size based on percentage of viewport
+        let targetSize = viewportMin * scale;
+
+        // Enforce Min Size constraint (visibility)
+        const minSize = calculateMinSize();
+        if (targetSize < minSize) {
+            targetSize = minSize;
+        }
+
+        // Apply size
+        wrapper.style.width = `${targetSize}px`;
+        wrapper.style.height = `${targetSize}px`;
+
+        // Reset CSS resize props if they were somehow left over
+        wrapper.style.resize = '';
+        wrapper.style.overflow = '';
+        wrapper.style.maxWidth = 'none';
+        wrapper.style.maxHeight = 'none';
+
+        // Trigger internal resize logic to update canvas
+        publicInterface.resize();
+    };
+
     const publicInterface = {
         init: function(initialSettings, initialState) {
             settings = initialSettings;
             globalState = initialState;
+
+            // Standard window resize listener
             window.addEventListener('resize', () => {
-                 if (!settings.manualResize) {
-                     this.resize();
-                 }
+                 applyClockSize();
             });
 
             document.addEventListener('flow-theme-changed', (e) => {
@@ -963,84 +910,13 @@ const Clock = (function() {
                 flowTransitionStartTime = Date.now();
             });
 
-            // Listen for manual resize toggle
-            document.addEventListener('settings-changed', () => {
-                 if (settings.manualResize !== (document.querySelector('.clock-square-wrapper').style.resize === 'both')) {
-                     applyResizeMode();
-                 }
-            });
-
-            // Listen for arc visibility changes (which trigger settings-requires-resize)
-            // to re-evaluate min/max size requirements
+            // Listen for slider changes
             document.addEventListener('settings-requires-resize', () => {
-                if (settings.manualResize) {
-                    const wrapper = document.querySelector('.clock-square-wrapper');
-                    if (wrapper) {
-                        const currentSize = parseFloat(wrapper.style.width) || 0;
-                        const minSize = calculateMinSize();
-                        const maxSize = Math.min(window.innerWidth, window.innerHeight);
-
-                        if (currentSize < minSize) {
-                             wrapper.style.width = `${minSize}px`;
-                             wrapper.style.height = `${minSize}px`;
-                             // Dispatch resize event or save new size?
-                             // Since this is programmatic, handleResizeEntry won't fire automatically unless observed.
-                             // But we just changed style, which WILL fire ResizeObserver if size changed.
-                        } else if (currentSize > maxSize) {
-                            wrapper.style.width = `${maxSize}px`;
-                            wrapper.style.height = `${maxSize}px`;
-                        }
-                    }
-                }
+                 applyClockSize();
             });
 
             // Initial application
-            // Check for saved size on init
-            const savedSize = localStorage.getItem('polarClockSize');
-            if (savedSize && settings.manualResize) {
-                try {
-                    const { size, windowWidth, windowHeight } = JSON.parse(savedSize);
-                    const wrapper = document.querySelector('.clock-square-wrapper');
-
-                    if (wrapper) {
-                        // Logic:
-                        // If window size matches (approx), restore size.
-                        // If window is smaller, scale down.
-                        // If window is larger, reset (or keep, but requirements say "return to default on larger screens").
-
-                        const widthDiff = Math.abs(window.innerWidth - windowWidth);
-                        const heightDiff = Math.abs(window.innerHeight - windowHeight);
-                        const isSameWindowSize = widthDiff < 50 && heightDiff < 50; // Tolerance
-
-                        if (isSameWindowSize) {
-                             wrapper.style.width = `${size}px`;
-                             wrapper.style.height = `${size}px`;
-                        } else if (window.innerWidth < windowWidth || window.innerHeight < windowHeight) {
-                            // Screen got smaller: Scale down to fit
-                            // Just let the standard "max-width: 100%" (or constraints) handle it?
-                            // Manual resize mode removes max-width. We must calc manually.
-                            const maxSize = Math.min(window.innerWidth, window.innerHeight);
-                            const newSize = Math.min(size, maxSize);
-                            wrapper.style.width = `${newSize}px`;
-                            wrapper.style.height = `${newSize}px`;
-                        } else {
-                            // Screen got larger: "return to default"
-                            // If we don't set width/height here, applyResizeMode will set a default start size
-                            // OR we can just reset the storage?
-                            // For now, let's just not apply the old small size, let it re-init.
-                            // But applyResizeMode sets it to current width/height or 500px.
-                            // Let's set it to a safe large default (viewport)
-                             const defaultSize = Math.min(window.innerWidth, window.innerHeight) * 0.95;
-                             wrapper.style.width = `${defaultSize}px`;
-                             wrapper.style.height = `${defaultSize}px`;
-                        }
-                    }
-                } catch (e) {
-                    console.error("Error loading saved clock size", e);
-                }
-            }
-
-            applyResizeMode();
+            applyClockSize();
 
             this.resume();
         },

--- a/js/settings.js
+++ b/js/settings.js
@@ -111,7 +111,7 @@ const Settings = (function() {
     function loadSettings() {
         const savedSettings = localStorage.getItem('polarClockSettings');
         const defaultSettings = {
-            manualResize: false,
+            clockScale: 95,
             flowMode: '0',
             showArcEndCircles: true,
             inverseMode: false,
@@ -156,7 +156,10 @@ const Settings = (function() {
 
     function applySettingsToUI() {
         // Standard settings
-        document.getElementById('manualResizeToggle').checked = settings.manualResize;
+        const scaleVal = settings.clockScale !== undefined ? settings.clockScale : 95;
+        document.getElementById('clockSizeSlider').value = scaleVal;
+        document.getElementById('clockSizeValue').textContent = `${scaleVal}%`;
+
         document.getElementById('format12').classList.toggle('active', !settings.is24HourFormat);
         document.getElementById('format24').classList.toggle('active', settings.is24HourFormat);
         // Update color scheme buttons
@@ -223,9 +226,16 @@ const Settings = (function() {
             };
         }
 
-        document.getElementById('manualResizeToggle').addEventListener('change', createSettingUpdater(() => {
-            settings.manualResize = document.getElementById('manualResizeToggle').checked;
-        }));
+        document.getElementById('clockSizeSlider').addEventListener('input', (e) => {
+             const val = parseInt(e.target.value, 10);
+             settings.clockScale = val;
+             document.getElementById('clockSizeValue').textContent = `${val}%`;
+             saveSettings();
+             // Dispatch generic change event
+             document.dispatchEvent(new CustomEvent('settings-changed'));
+             // Dispatch resize event specifically
+             document.dispatchEvent(new CustomEvent('settings-requires-resize'));
+        });
 
         document.getElementById('format12').addEventListener('click', createSettingUpdater(() => { settings.is24HourFormat = false; }));
         document.getElementById('format24').addEventListener('click', createSettingUpdater(() => { settings.is24HourFormat = true; }));


### PR DESCRIPTION
- Replaced "Manual Resize" toggle with a responsive "Clock Size" slider in Settings.
- Implemented percentage-based resizing (10-100% of viewport) in `js/clock.js`.
- Enforced minimum size constraints to ensure legibility based on visible arcs.
- Maintained square aspect ratio and viewport bounds automatically.
- Persisted scale preference to `localStorage`.
- Cleaned up previous drag/resize logic.