### PR TITLE
Implement New Year's Eve mode and fix week display logic.

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -409,7 +409,15 @@ const Clock = (function() {
         const dayNum = d.getUTCDay() || 7;
         d.setUTCDate(d.getUTCDate() + 4 - dayNum);
         const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-        return Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+        const weekNo = Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+
+        // Visual Fix: If it's December and we got Week 1, it means we rolled over.
+        // Force it to be the last week of the current year for visual consistency.
+        if (date.getMonth() === 11 && weekNo === 1) {
+            return getTotalWeeksInYear(date.getFullYear());
+        }
+
+        return weekNo;
     };
 
     const getLabelText = (unit, now) => {


### PR DESCRIPTION
- Move `Auld_Lang_Syne-Maeve_Lander.mp3` to `assets/Sounds/`.
- Add `getNow()` helper and `timeOffset` state to `js/clock.js` for time simulation.
- Implement `startNewYearsMode` to trigger 1m45s before midnight on Dec 31st:
  - Forces all arcs visible.
  - Plays audio synchronized to current time offset.
  - Sets volume to 100% (independent of app volume).
- Add `Clock.simulateNewYear()` to public interface for manual testing.
- Modify `getWeekOfYear` to force dates in late December to display as the last week of the current year (52/53) instead of Week 1, ensuring the visual arc is full.